### PR TITLE
Changed Disk Buffersize to resolve issue with large file transfers to SPI flash.

### DIFF
--- a/src/MTP_Teensy.h
+++ b/src/MTP_Teensy.h
@@ -102,7 +102,7 @@ private:
 
   uint8_t tx_data_buffer[MTP_TX_SIZE] __attribute__((aligned(32)));
 
-  static const uint32_t DISK_BUFFER_SIZE = 8 * 1024;
+  static const uint32_t DISK_BUFFER_SIZE = 2 * 1024;
   uint32_t disk_pos = 0;
 
   int push_packet(uint8_t *data_buffer, uint32_t len);


### PR DESCRIPTION
Based on our conversations was playing with the diskbuffer size for the T4 to resolve the issue with transferring a 22.mb (large file) to flash,  NAND didn't seem to have the issue.  Tried changing from 8 to 4 - slight improvement - got further.  Changing to:
`DISK_BUFFER_SIZE = 2 * 1024;`
worked.....

EDIT:  this is half the block size:
config.block_size = info->erasesize;  

Erasesize is 4096