### PR TITLE
Make storage part of MTPD plus rename and have explicit one

### DIFF
--- a/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
+++ b/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
@@ -5,8 +5,6 @@
 #error "This only runs on a Teesny 4.1 with a QSPI Flash chip installed on bottom of board"
 #endif
 
-MTPStorage storage;     // TODO: storage inside MTP instance, not separate class
-MTPD    MTP(&storage);  // TODO: MTP instance created by default
 
 LittleFS_QSPI qspi;
 void setup()
@@ -25,7 +23,7 @@ void setup()
   
   // try to add QSPI Flash
   if (qspi.begin()) {
-    storage.addFilesystem(qspi, qspi.displayName());
+    MTP.addFilesystem(qspi, qspi.displayName());
   } else {
     Serial.println("No QSPI Flash found");
   }
@@ -42,14 +40,14 @@ void loop()
     switch (command) {
       case '1':
         // first dump list of storages:
-        fsCount = storage.getFSCount();
+        fsCount = MTP.storage()->getFSCount();
         Serial.printf("\nDump Storage list(%u)\n", fsCount);
         for (uint32_t ii = 0; ii < fsCount; ii++) {
           Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii, MTP.Store2Storage(ii),
-                           storage.getStoreName(ii), (uint32_t)storage.getStoreFS(ii));
+                           MTP.storage()->getStoreName(ii), (uint32_t)MTP.storage()->getStoreFS(ii));
         }
         Serial.println("\nDump Index List");
-        storage.dumpIndexList();
+        MTP.storage()->dumpIndexList();
         break;
       case'r':
         Serial.println("Reset");

--- a/examples/Simplified Examples/Example_3_simple_SD/Example_3_simple_SD.ino
+++ b/examples/Simplified Examples/Example_3_simple_SD/Example_3_simple_SD.ino
@@ -3,10 +3,6 @@
 
 #define CS_SD BUILTIN_SDCARD  // Works on T_3.6 and T_4.1
 //#define CS_SD 10  // Works on SPI with this CS pin
-
-MTPStorage storage;     // TODO: storage inside MTP instance, not separate class
-MTPD    MTP(&storage);  // TODO: MTP instance created by default
-
 void setup()
 {
   Serial.begin(9600);
@@ -14,16 +10,12 @@ void setup()
     // wait for serial port to connect.
   }
 
-  Serial.print(CrashReport);
-  Serial.println("\n" __FILE__ " " __DATE__ " " __TIME__);
-  delay(1000);
-
   // mandatory to begin the MTP session.
   MTP.begin();
 
   // Add SD Card
   if (SD.begin(CS_SD)) {
-    storage.addFilesystem(SD, "SD Card");
+    MTP.addFilesystem(SD, "SD Card");
     Serial.println("Added SD card using built in SDIO, or given SPI CS");
   } else {
     Serial.println("No SD Card");

--- a/examples/simple_mtp_hardware/TeensyFS.h
+++ b/examples/simple_mtp_hardware/TeensyFS.h
@@ -1,0 +1,271 @@
+#ifndef __TeensyFS_H__
+#define __TeensyFS_H__
+#include <Arduino.h>
+#include <FS.h>
+
+//#define USE_PRINTF_DEBUG // Serial4 kernel...
+#ifdef USE_PRINTF_DEBUG
+#define DBGPRINTF(...) printf_debug(__VA_ARGS__)
+extern "C" {
+	void printf_debug(const char *format, ...);
+}
+#else
+#define DBGPRINTF(...)
+#endif
+//-----------------------------------------------------------------------------
+// digital pins file
+//-----------------------------------------------------------------------------
+class TFSDPFile : public  FileImpl {
+public:
+	TFSDPFile(uint8_t pin_index, uint8_t mode) {
+		_pin_index = pin_index;
+		_fOpen = true;
+		snprintf(_name, sizeof(_name), "%d.txt", _pin_index);
+		updateValue();
+		_position = 0;
+		Serial.printf("\n@@@@D@@@@@ TFSDPFile::TFSDPFile %u %s=%s\n", _pin_index, _name, _value);
+	};
+
+	~TFSDPFile() {close(); }
+
+
+	virtual size_t read(void *buf, size_t nbyte) {
+		Serial.printf("))read(%x %u) %u\n", (uint32_t)buf, nbyte, _position);
+		char *p = (char*)buf;
+		int cb = 0;
+		while (nbyte && (_position < _value_len)) {
+			*p++ = _value[_position++];
+			nbyte--;
+			cb++;
+		}
+		return cb;
+	}
+	virtual size_t write(const void *buf, size_t size) { 
+		// hack not going to look at other data in file...
+		const char *p = (const char*)buf; 
+		if (size) {
+			if (*p == '0') digitalWrite(_pin_index, 0);
+			else if (*p == '1') digitalWrite(_pin_index, 1);
+			updateValue();
+			return size;
+		}
+		return 0; 
+	}
+	virtual int available() {return (_position < _value_len) ? _value_len - _position : 0;}
+	virtual int peek() { return (_position < _value_len) ? _value[_position] : -1;}
+	virtual void flush() {}
+	virtual bool truncate(uint64_t size = 0) {Serial.printf("))truncate %u\n", (uint32_t)size);return true;};
+	virtual bool seek(uint64_t pos, int mode) {Serial.printf("))seek %u %u\n", (uint32_t)pos, mode);_position = pos; return false;} // should look at mode
+	virtual uint64_t position()  { return _position;}
+	virtual uint64_t size()  { return _value_len;}
+	virtual void close() {_fOpen = false; }
+	virtual bool isOpen() {return _fOpen;}
+	virtual const char* name() { return _name; }
+	virtual bool isDirectory() { return false;}
+	virtual File openNextFile(uint8_t mode = 0) {return File();}
+	virtual void rewindDirectory(void) {};
+	virtual bool setCreateTime(const DateTimeFields &tm) { return false;}
+	virtual bool setModifyTime(const DateTimeFields &tm) { return false;}
+
+	bool _fOpen;
+	uint8_t _pin_index;
+	char _name[10]; // enough room for a name.
+	uint8_t _value[3];
+	uint8_t _value_len = 2;
+	uint8_t _position;
+
+	void updateValue() {
+		_value[0] = digitalRead(_pin_index) ? '1' : '0';
+		_value[1] = '\n';
+		_value[2] = '\0';
+		_value_len = 2;		
+	}
+
+	static uint8_t mapFilenameToIndex(const char *filename) {
+		uint8_t index = 0;
+		while ((*filename >= '0') && (*filename <= '9') ) {
+			index = index * 10 + *filename++ - '0';
+		}
+		if (*filename == '\0') return index;
+		return 0xff;
+	}
+};
+
+//-----------------------------------------------------------------------------
+// Analog pins file
+//-----------------------------------------------------------------------------
+extern float tempmonGetTemp(void);
+class TFSAPFile : public  FileImpl {
+public:
+	TFSAPFile(uint8_t pin_index, uint8_t mode) {
+		_pin_index = pin_index;
+		_fOpen = true;
+		// lets get the current analog voltage for that pin.
+		if (_pin_index == 0) snprintf(_value, sizeof(_value), "%6.2f\n", tempmonGetTemp()); // temp
+		else if (_pin_index == 1) snprintf(_value, sizeof(_value), "%4u\n", 0); // voltage remember where?
+		else snprintf(_value, sizeof(_value), "%4u\n", analogRead(_pin_index - 2)); // random pin.
+		_value_len = strlen(_value);
+		Serial.printf("\n@@@@A@@@@@ TFSAPFile::TFSAPFile %u %s=%s\n", _pin_index, _names[_pin_index], _value);
+	};
+
+	~TFSAPFile() {close(); }
+
+	virtual size_t read(void *buf, size_t nbyte) {
+		char *p = (char*)buf;
+		int cb = 0;
+		while (nbyte && (_position < _value_len)) {
+			*p++ = _value[_position++];
+			nbyte--;
+			cb++;
+		}
+		return cb;
+	}
+	virtual size_t write(const void *buf, size_t size) { return 0; }
+	virtual int available() {return (_position < _value_len) ? _value_len - _position : 0;}
+	virtual int peek() { return (_position < _value_len) ? _value[_position] : -1;}
+	virtual void flush() {}
+	virtual bool truncate(uint64_t size = 0) {return true;};
+	virtual bool seek(uint64_t pos, int mode) {_position = pos; return false;} // should look at mode
+	virtual uint64_t position()  { return _position;}
+	virtual uint64_t size()  { return _value_len;}
+	virtual void close() {_fOpen = false; }
+	virtual bool isOpen() {return _fOpen;}
+	virtual const char* name() { return _names[_pin_index]; }
+	virtual bool isDirectory() { return false;}
+	virtual File openNextFile(uint8_t mode = 0) {return File();}
+	virtual void rewindDirectory(void) {};
+	virtual bool setCreateTime(const DateTimeFields &tm) { return false;}
+	virtual bool setModifyTime(const DateTimeFields &tm) { return false;}
+	bool _fOpen = false;
+	uint8_t _pin_index;
+	uint8_t _position = 0;
+	char _value[10] = "0000\n";
+	uint8_t _value_len = _value_len;
+	static const char *_names[12];
+	static uint8_t mapFilenameToIndex(const char *filename) {
+		for (uint8_t index = 0; index < (sizeof(_names) / sizeof(_names[0])); index++) {
+			if (strcmp(filename, _names[index]) == 0) return index;
+		}
+		return 0xff;
+	}
+};
+const char *TFSAPFile::_names[12] = {"Temp.txt", "Volt.txt", "A0.txt", "A1.txt", "A2.txt", 
+		"A3.txt", "A4.txt", "A5.txt", "A6.txt", "A7.txt", "A8.txt", "A9.txt"};
+
+//-----------------------------------------------------------------------------
+// Files in the root
+//-----------------------------------------------------------------------------
+class TFSRootFile : public  FileImpl {
+public:
+	TFSRootFile(uint8_t root_index, uint8_t mode) {
+		_root_index = root_index;
+		_fOpen = true;
+		_child_index = 0;
+	};
+	enum {NUM_CHILD_DIGITAL = 24, NUM_CHILD_ANALOG = 12};
+	~TFSRootFile() {close(); }
+	virtual size_t read(void *buf, size_t nbyte) { return 0; }
+	virtual size_t write(const void *buf, size_t size) { return 0; }
+	virtual int available() { return 0;}
+	virtual int peek() {return -1;}
+	virtual void flush() {}
+	virtual bool truncate(uint64_t size = 0) {return true;};
+	virtual bool seek(uint64_t pos, int mode) {return false;}
+	virtual uint64_t position()  { return 0;}
+	virtual uint64_t size()  { return 0;}
+	virtual void close() {_fOpen = false; }
+	virtual bool isOpen() {return _fOpen;}
+	virtual const char* name() {
+		switch (_root_index) {
+		case 0: return (const char *)F("Digital"); break;
+		default: return (const char *)F("Analog"); break;
+		}
+	}
+	virtual bool isDirectory() { return true;}
+	virtual File openNextFile(uint8_t mode = 0) {
+		if (_root_index == 0) {
+			if (_child_index < NUM_CHILD_DIGITAL) return File(new TFSDPFile(_child_index++, mode));
+		} else {
+			if (_child_index < NUM_CHILD_ANALOG) return File(new TFSAPFile(_child_index++, mode));
+		}
+		return File();
+	}
+	virtual void rewindDirectory(void) {_child_index = 0;};
+	virtual bool setCreateTime(const DateTimeFields &tm) { return false;}
+	virtual bool setModifyTime(const DateTimeFields &tm) { return false;}
+	bool _fOpen;
+	uint8_t _child_index = 0;
+	uint8_t _root_index;
+};
+
+
+//-----------------------------------------------------------------------------
+// root
+//-----------------------------------------------------------------------------
+class TFSRoot : public  FileImpl {
+public:
+	TFSRoot(int8_t mode) {
+		_fOpen = true;
+		_child_index = 0;
+	};
+	enum {NUM_CHILD_OBJECTS = 2};
+	~TFSRoot() {close(); }
+	virtual size_t read(void *buf, size_t nbyte) { return 0; }
+	virtual size_t write(const void *buf, size_t size) { return 0; }
+	virtual int available() { return 0;}
+	virtual int peek() {return -1;}
+	virtual void flush() {}
+	virtual bool truncate(uint64_t size = 0) {return true;};
+	virtual bool seek(uint64_t pos, int mode) {return false;}
+	virtual uint64_t position()  { return 0;}
+	virtual uint64_t size()  { return 0;}
+	virtual void close() {_fOpen = false; }
+	virtual bool isOpen() {return _fOpen;}
+	virtual const char* name() {return "/";}
+	virtual bool isDirectory() { return true;}
+	virtual File openNextFile(uint8_t mode = 0) {
+		if (_child_index < NUM_CHILD_OBJECTS) return File(new TFSRootFile(_child_index++, mode));
+		return File();
+	}
+	virtual void rewindDirectory(void) {_child_index = 0;};
+	virtual bool setCreateTime(const DateTimeFields &tm) { return false;}
+	virtual bool setModifyTime(const DateTimeFields &tm) { return false;}
+	bool _fOpen;
+	int8_t _child_index = 0;
+};
+
+//-----------------------------------------------------------------------------
+// File System
+//-----------------------------------------------------------------------------
+class TeensyFS : public FS
+{
+public:
+	TeensyFS() {};
+	virtual File open(const char *filename, uint8_t mode = FILE_READ);
+	virtual bool exists(const char *filepath) {Serial.printf("TeensyFS::exists(%s)\n", filepath); return true;}
+	virtual bool mkdir(const char *filepath)  {Serial.printf("TeensyFS::mkdir(%s)\n", filepath); return true;}
+	virtual bool rename(const char *oldfilepath, const char *newfilepath) {Serial.printf("TeensyFS::rename(%s, %s)\n", oldfilepath, newfilepath); return true;}
+	virtual bool remove(const char *filepath)  {Serial.printf("TeensyFS::remove(%s)\n", filepath); return true;}
+	virtual bool rmdir(const char *filepath)  { Serial.printf("TeensyFS::rmdir(%s)\n", filepath); return true;}
+	virtual uint64_t usedSize()  { return 0ul;}
+	virtual uint64_t totalSize() { return 1000ul;}
+};
+
+File TeensyFS::open(const char *filename, uint8_t mode) {
+	// This is crud...
+	Serial.printf("@@@ TeensyFS::open %s %u\n", filename, mode);
+	if (strcmp(filename, "/") == 0) return File(new TFSRoot(mode));
+	if (strcmp(filename, "/Digital") == 0) return File(new TFSRootFile(0, mode));
+	if (strcmp(filename, "/Analog") == 0) return File(new TFSRootFile(1, mode));
+	if (strncmp(filename, "/Digital/", 9) == 0) {
+		uint8_t index = TFSDPFile::mapFilenameToIndex(&filename[9]);
+		if (index != 0XFF) return File(new TFSDPFile(index, mode));
+	}
+	else if (strncmp(filename, "/Analog/", 8) == 0) {
+		uint8_t index = TFSAPFile::mapFilenameToIndex(&filename[8]);
+		if (index != 0XFF) return File(new TFSAPFile(index, mode));
+	}
+	return File();
+}
+
+#endif // __TeensyFS_H__

--- a/examples/simple_mtp_hardware/simple_mtp_hardware.ino
+++ b/examples/simple_mtp_hardware/simple_mtp_hardware.ino
@@ -1,0 +1,202 @@
+/*
+*/
+#include <MTP_Teensy.h>
+
+File dataFile; // Specifes that dataFile is of File type
+
+int record_count = 0;
+bool write_data = false;
+uint32_t diskSize;
+
+FS *myfs;
+
+#define USE_MEMORY_FS
+
+uint32_t MEMFS_SIZE = 65536; // probably more than enough...
+#ifdef USE_MEMORY_FS
+#include <MemFile.h>
+MemFS memfs;
+#else
+#include <LittleFS.h>
+LittleFS_RAM lfsram;
+#endif
+#include "TeensyFS.h"
+TeensyFS teensyfs;
+
+
+#ifdef ARDUINO_TEENSY41
+extern "C" uint8_t external_psram_size;
+#endif
+
+
+void setup() {
+  // Open serial communications and wait for port to open:
+  Serial.begin(115200);
+//  Serial4.begin(115200);  // Use to echo stuff out for debug core.
+  while (!Serial && millis() < 5000) {
+    // wait for serial port to connect.
+  }
+  Serial.print(CrashReport);
+  Serial.println("\n" __FILE__ " " __DATE__ " " __TIME__);
+  delay(3000);
+
+  // startup mtp.. SO to not timeout...
+  MTP.begin();
+// lets initialize a RAM drive.
+#if defined ARDUINO_TEENSY41
+  if (external_psram_size)
+    MEMFS_SIZE = 4 * 1024 * 1024;
+#endif
+#ifdef USE_MEMORY_FS
+  if (memfs.begin(MEMFS_SIZE)) {
+    Serial.printf("Memory Drive of size: %u initialized\n", MEMFS_SIZE);
+    uint32_t istore = MTP.addFilesystem(memfs, "RAM");
+    Serial.printf("Set Storage Index drive to %u\n", istore);
+  }
+  myfs = &memfs;  // so we don't start of with NULL pointer
+#else
+  if (lfsram.begin(MEMFS_SIZE)) {
+    Serial.printf("Ram Drive of size: %u initialized\n", MEMFS_SIZE);
+    uint32_t istore = MTP.addFilesystem(lfsram, "RAM");
+    Serial.printf("Set Storage Index drive to %u\n", istore);
+  }
+  myfs = &lfsram;  // so we don't start of with NULL pointer
+#endif
+
+  MTP.addFilesystem(teensyfs, "Hardware");
+
+  Serial.println("MTP initialized.");
+  menu();
+}
+
+void loop() {
+  MTP.loop();
+
+  if (Serial.available()) {
+    uint8_t command = Serial.read();
+    int ch = Serial.read();
+    uint32_t drive_index = CommandLineReadNextNumber(ch, 0);
+    while (ch == ' ')
+      ch = Serial.read();
+
+    switch (command) {
+    case 'l':
+      listFiles();
+      break;
+    case 'e':
+      eraseFiles();
+      break;
+    case '1': {
+      // first dump list of storages:
+      uint32_t fsCount = MTP.storage()->getFSCount();
+      Serial.printf("\nDump Storage list(%u)\n", fsCount);
+      for (uint32_t ii = 0; ii < fsCount; ii++) {
+        Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
+                      MTP.Store2Storage(ii), MTP.storage()->getStoreName(ii),
+                      (uint32_t)MTP.storage()->getStoreFS(ii));
+      }
+      Serial.println("\nDump Index List");
+      MTP.storage()->dumpIndexList();
+    } break;
+    case '2':
+      Serial.printf("Drive # %d Selected\n", drive_index);
+      myfs = MTP.storage()->getStoreFS(drive_index);
+      break;
+    case 'r':
+      Serial.println("Send Device Reset Event");
+      MTP.send_DeviceResetEvent();
+      break;
+    case '\r':
+    case '\n':
+    case 'h':
+      menu();
+      break;
+    default:
+      menu();
+      break;
+    }
+    while (Serial.read() != -1)
+      ; // remove rest of characters.
+  }
+}
+
+void menu() {
+  Serial.println();
+  Serial.println("Menu Options:");
+  Serial.println("\t1 - List Drives (Step 1)");
+  Serial.println("\t2 - Select Drive");
+  Serial.println("\tl - List files");
+  Serial.println("\te - Erase files");
+  Serial.println("\tr - reset MTP");
+  Serial.println("\th - Menu");
+  Serial.println();
+}
+
+void listFiles() {
+  Serial.print("\n Space Used = ");
+  Serial.println(myfs->usedSize());
+  Serial.print("Filesystem Size = ");
+  Serial.println(myfs->totalSize());
+
+  File root = myfs->open("/");
+  printDirectory(root, 0);
+  root.close();
+}
+
+void eraseFiles() {
+  Serial.println("\n*** Erase/Format started ***");
+  myfs->format(0, '.', Serial);
+  Serial.println("Completed, sending device reset event");
+  MTP.send_DeviceResetEvent();
+}
+
+void printDirectory(File dir, int numSpaces) {
+  DateTimeFields dtf;
+  while (true) {
+    File entry = dir.openNextFile();
+    if (!entry) {
+      // Serial.println("** no more files **");
+      break;
+    }
+    printSpaces(numSpaces);
+    Serial.print(entry.name());
+    printSpaces(36 - numSpaces - strlen(entry.name()));
+
+    if (entry.getCreateTime(dtf)) {
+      Serial.printf(" C: %02u/%02u/%04u %02u:%02u", dtf.mon + 1, dtf.mday, dtf.year + 1900, dtf.hour, dtf.min );
+    }
+
+    if (entry.getModifyTime(dtf)) {
+      Serial.printf(" M: %02u/%02u/%04u %02u:%02u", dtf.mon + 1, dtf.mday, dtf.year + 1900, dtf.hour, dtf.min );
+    }
+    if (entry.isDirectory()) {
+      Serial.println("  /");
+      printDirectory(entry, numSpaces + 2);
+    } else {
+      // files have sizes, directories do not
+      Serial.print("  ");
+      Serial.println(entry.size(), DEC);
+    }
+    entry.close();
+  }
+}
+
+void printSpaces(int num) {
+  for (int i = 0; i < num; i++) {
+    Serial.print(" ");
+  }
+}
+
+uint32_t CommandLineReadNextNumber(int &ch, uint32_t default_num) {
+  while (ch == ' ')
+    ch = Serial.read();
+  if ((ch < '0') || (ch > '9'))
+    return default_num;
+
+  uint32_t return_value = 0;
+  while ((ch >= '0') && (ch <= '9')) {
+    return_value = return_value * 10 + ch - '0';
+    ch = Serial.read();
+  }
+  return return_value;
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,14 @@
+MTP	KEYWORD1
+begin	KEYWORD2
+addFilesystem	KEYWORD2
+loop	KEYWORD2
+storage	KEYWORD2
+Store2Storage	KEYWORD2
+addSendObjectBuffer	KEYWORD2
+send_Event	KEYWORD2
+send_addObjectEvent	KEYWORD2
+send_removeObjectEvent	KEYWORD2
+send_StorageInfoChangedEvent	KEYWORD2
+send_DeviceResetEvent	KEYWORD2
+send_StoreAddedEvent	KEYWORD2
+send_StoreRemovedEvent	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -9,3 +9,4 @@ category=Data Storage
 url=https://github.com/KurtE/MTP_Teensy
 repository=https://github.com/KurtE/MTP_Teensy.git
 architectures=*
+includes=MTP_Teensy.h

--- a/src/MTP_Storage.cpp
+++ b/src/MTP_Storage.cpp
@@ -44,22 +44,22 @@
 
 #if USE_DBG_MACROS == 1
 static void dbgPrint(uint16_t line) {
-  MTPD::PrintStream()->print(F("DBG_FAIL: "));
-  MTPD::PrintStream()->print(F(DBG_FILE));
-  MTPD::PrintStream()->write('.');
-  MTPD::PrintStream()->println(line);
+  MTP_class::PrintStream()->print(F("DBG_FAIL: "));
+  MTP_class::PrintStream()->print(F(DBG_FILE));
+  MTP_class::PrintStream()->write('.');
+  MTP_class::PrintStream()->println(line);
 }
 
 #define DBG_PRINT_IF(b)                                                        \
   if (b) {                                                                     \
-    MTPD::PrintStream()->print(F(__FILE__));                                   \
-    MTPD::PrintStream()->println(__LINE__);                                    \
+    MTP_class::PrintStream()->print(F(__FILE__));                                   \
+    MTP_class::PrintStream()->println(__LINE__);                                    \
   }
 #define DBG_HALT_IF(b)                                                         \
   if (b) {                                                                     \
-    MTPD::PrintStream()->print(F("DBG_HALT "));                                \
-    MTPD::PrintStream()->print(F(__FILE__));                                   \
-    MTPD::PrintStream()->println(__LINE__);                                    \
+    MTP_class::PrintStream()->print(F("DBG_HALT "));                                \
+    MTP_class::PrintStream()->print(F(__FILE__));                                   \
+    MTP_class::PrintStream()->println(__LINE__);                                    \
     while (true) {                                                             \
     }                                                                          \
   }
@@ -71,7 +71,7 @@ static void dbgPrint(uint16_t line) {
 #endif // USE_DBG_MACROS
 
 #if DEBUG > 1
-#define DBGPrintf(...) MTPD::PrintStream()->printf(__VA_ARGS__)
+#define DBGPrintf(...) MTP_class::PrintStream()->printf(__VA_ARGS__)
 #else
 #define DBGPrintf(...)
 #endif
@@ -113,7 +113,7 @@ void MTPStorage::OpenIndex()
 	if (index_) return; // only once
 	mtp_lock_storage(true);
 	index_ = open(index_file_storage_, indexFile, FILE_WRITE_BEGIN);
-	if (!index_) MTPD::PrintStream()->println("cannot open Index file");
+	if (!index_) MTP_class::PrintStream()->println("cannot open Index file");
 	mtp_lock_storage(false);
 	user_index_file_ = false; // opened up default file so make sure off
 }
@@ -158,7 +158,7 @@ uint32_t MTPStorage::AppendIndexRecord(const Record &r)
 
 
 // TODO(hubbe): Cache a few records for speed.
-Record MTPStorage::ReadIndexRecord(uint32_t i)
+ MTPStorage::Record MTPStorage::ReadIndexRecord(uint32_t i)
 {
 	Record ret;
 	//memset(&ret, 0, sizeof(ret));
@@ -242,7 +242,7 @@ void MTPStorage::GenerateIndex(uint32_t store)
 {
 	if (index_generated) return;
 	index_generated = true;
-  MTPD::PrintStream()->println("*** MTPStorage::GenerateIndex called ***"); 
+  MTP_class::PrintStream()->println("*** MTPStorage::GenerateIndex called ***"); 
 	// first remove old index file
 	mtp_lock_storage(true);
 	if (user_index_file_) {
@@ -300,7 +300,7 @@ void MTPStorage::ScanDir(uint32_t store, uint32_t i)
 			r.dtModify = child_.getModifyTime(dtf) ? makeTime(dtf) : 0;
 			r.dtCreate = child_.getCreateTime(dtf) ? makeTime(dtf) : 0;
 			sibling = AppendIndexRecord(r);
-      MTPD::PrintStream()->print("  >> "); 
+      MTP_class::PrintStream()->print("  >> "); 
       printRecordIncludeName(sibling, &r);
 			child_.close();
 		}
@@ -562,10 +562,10 @@ uint32_t MTPStorage::Create(uint32_t store, uint32_t parent, bool folder, const 
 		DBGPrintf("    >>(%u, %s)\n", ret, filename);
 		mtp_lock_storage(true);
 		mkdir(store, filename);
-		MTPD::PrintStream()->println("    >> After mkdir"); MTPD::PrintStream()->flush();
+		MTP_class::PrintStream()->println("    >> After mkdir"); MTP_class::PrintStream()->flush();
 		mtp_lock_storage(false);
 		OpenFileByIndex(ret, FILE_READ);
-		MTPD::PrintStream()->println("    >> After OpenFileByIndex"); MTPD::PrintStream()->flush();
+		MTP_class::PrintStream()->println("    >> After OpenFileByIndex"); MTP_class::PrintStream()->flush();
 		if (!file_) {
 			DBGPrintf(
 				"MTPStorage::Create %s failed to open folder\n", filename);
@@ -595,20 +595,20 @@ uint32_t MTPStorage::Create(uint32_t store, uint32_t parent, bool folder, const 
 		}
 	}
 #if DEBUG > 1
-	MTPD::PrintStream()->print("Create ");
-	MTPD::PrintStream()->print(ret);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->print(store);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->print(parent);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->print(folder);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->print(r.dtModify);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->print(r.dtCreate);
-	MTPD::PrintStream()->print(" ");
-	MTPD::PrintStream()->println(filename);
+	MTP_class::PrintStream()->print("Create ");
+	MTP_class::PrintStream()->print(ret);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->print(store);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->print(parent);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->print(folder);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->print(r.dtModify);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->print(r.dtCreate);
+	MTP_class::PrintStream()->print(" ");
+	MTP_class::PrintStream()->println(filename);
 #endif
 	return ret;
 }
@@ -647,7 +647,7 @@ bool MTPStorage::rename(uint32_t handle, const char *name)
 	char temp[MAX_FILENAME_LEN];
 
 	uint16_t store = ConstructFilename(handle, oldName, MAX_FILENAME_LEN);
-	MTPD::PrintStream()->println(oldName);
+	MTP_class::PrintStream()->println(oldName);
 
 	Record p1 = ReadIndexRecord(handle);
 	strlcpy(temp, p1.name, MAX_FILENAME_LEN);
@@ -655,7 +655,7 @@ bool MTPStorage::rename(uint32_t handle, const char *name)
 
 	WriteIndexRecord(handle, p1);
 	ConstructFilename(handle, newName, MAX_FILENAME_LEN);
-	MTPD::PrintStream()->println(newName);
+	MTP_class::PrintStream()->println(newName);
 
 	if (rename(store, oldName, newName)) return true;
 
@@ -672,7 +672,7 @@ void MTPStorage::dumpIndexList(void)
 	for (uint32_t ii = 0; ii < index_entries_; ii++) {
 		if ((ii < fsCount) || (ii >= MTPD_MAX_FILESYSTEMS)) {
 			Record p = ReadIndexRecord(ii);
-			MTPD::PrintStream()->printf("%d: %d %d %u %d %d %d %u %u %s\n",
+			MTP_class::PrintStream()->printf("%d: %d %d %u %d %d %d %u %u %s\n",
 				ii, p.store, p.isdir, p.scanned, p.parent, p.sibling, p.child,
 				p.dtCreate, p.dtModify, p.name);
 		}
@@ -682,13 +682,13 @@ void MTPStorage::dumpIndexList(void)
 
 void MTPStorage::printRecord(int h, Record *p)
 {
-	MTPD::PrintStream()->printf("%d: %d %d %d %d %d\n", h, p->store, p->isdir,
+	MTP_class::PrintStream()->printf("%d: %d %d %d %d %d\n", h, p->store, p->isdir,
                               p->parent, p->sibling, p->child);
 }
 
 void MTPStorage::printRecordIncludeName(int h, Record *p)
 {
-	MTPD::PrintStream()->printf("%d: %u %u %u %u %u %u %u %u %s\n", h, p->store,
+	MTP_class::PrintStream()->printf("%d: %u %u %u %u %u %u %u %u %s\n", h, p->store,
                               p->isdir, p->scanned, p->parent, p->sibling,
                               p->child, p->dtModify, p->dtCreate, p->name);
 }
@@ -742,7 +742,7 @@ bool MTPStorage::move(uint32_t handle, uint32_t newStore, uint32_t newParent)
 	strlcat(newName, p1.name, MAX_FILENAME_LEN);
 	DBGPrintf("    >>From:%u %s to:%u %s\n", p1.store, oldName, newStore, newName);
 	if (p1.store == newStore) {
-			MTPD::PrintStream()->println("  >> Move same storage");
+			MTP_class::PrintStream()->println("  >> Move same storage");
 		if (!rename(newStore, oldName, newName)) {
 			DBG_FAIL_MACRO;
 			setLastError(RENAME_FAIL);
@@ -750,7 +750,7 @@ bool MTPStorage::move(uint32_t handle, uint32_t newStore, uint32_t newParent)
 			return false;
 		}
 	} else if (!p1.isdir) {
-			MTPD::PrintStream()->println("  >> Move differnt storage file");
+			MTP_class::PrintStream()->println("  >> Move differnt storage file");
 		if (CopyByPathNames(p1.store, oldName, newStore, newName)) {
 			remove(p1.store, oldName);
 		} else {
@@ -758,7 +758,7 @@ bool MTPStorage::move(uint32_t handle, uint32_t newStore, uint32_t newParent)
 			return false;
 		}
 	} else { // move directory cross mtp-disks
-			MTPD::PrintStream()->println("  >> Move differnt storage directory");
+			MTP_class::PrintStream()->println("  >> Move differnt storage directory");
 		if (!moveDir(p1.store, oldName, newStore, newName)) {
 			DBG_FAIL_MACRO;
 			return false;
@@ -914,8 +914,8 @@ bool MTPStorage::CopyFiles(uint32_t handle, uint32_t newHandle)
 }
 
 #if defined(__IMXRT1062__)
-	#define COPY_BUFFER MTPD::disk_buffer_
-	#define COPY_BUFFER_SIZE MTPD::DISK_BUFFER_SIZE
+	#define COPY_BUFFER MTP_class::disk_buffer_
+	#define COPY_BUFFER_SIZE MTP_class::DISK_BUFFER_SIZE
 #else
 	#define COPY_BUFFER (copy_buffer)
 	#define COPY_BUFFER_SIZE 512
@@ -986,7 +986,7 @@ bool MTPStorage::CompleteCopyFile(uint32_t from, uint32_t to)
 	r.child = (uint32_t)file_.size();
 	WriteIndexRecord(to, r);
 #if DEBUG > 1
-	MTPD::PrintStream()->print("  >>"); printRecordIncludeName(to, &r);
+	MTP_class::PrintStream()->print("  >>"); printRecordIncludeName(to, &r);
 #endif
 	file_.close();
 	mtp_lock_storage(false);
@@ -1003,14 +1003,14 @@ bool MTPStorage::CopyByPathNames(uint32_t store0, char *oldfilename, uint32_t st
 	int nd = -1;
 
 #if DEBUG > 1
-	MTPD::PrintStream()->print("MTPStorage::CopyByPathNames - From ");
-	MTPD::PrintStream()->print(store0);
-	MTPD::PrintStream()->print(": ");
-	MTPD::PrintStream()->println(oldfilename);
-	MTPD::PrintStream()->print("To   ");
-	MTPD::PrintStream()->print(store1);
-	MTPD::PrintStream()->print(": ");
-	MTPD::PrintStream()->println(newfilename);
+	MTP_class::PrintStream()->print("MTPStorage::CopyByPathNames - From ");
+	MTP_class::PrintStream()->print(store0);
+	MTP_class::PrintStream()->print(": ");
+	MTP_class::PrintStream()->println(oldfilename);
+	MTP_class::PrintStream()->print("To   ");
+	MTP_class::PrintStream()->print(store1);
+	MTP_class::PrintStream()->print(": ");
+	MTP_class::PrintStream()->println(newfilename);
 #endif
 
 	File f1 = open(store0, oldfilename, FILE_READ);
@@ -1160,7 +1160,7 @@ uint32_t MTPStorage::MapFileNameToIndex(uint32_t storage, const char *pathname,
 
 		} else {
 			// item not found
-			MTPD::PrintStream()->println("Node Not found");
+			MTP_class::PrintStream()->println("Node Not found");
 
 			if ((*path_parser != '\0') || !addLastNode) {
 				return 0xFFFFFFFFUL; // not found nor added

--- a/src/MTP_Storage.h
+++ b/src/MTP_Storage.h
@@ -42,21 +42,20 @@
 #endif
 
 
-struct Record {
-  uint32_t parent;
-  uint32_t child; // size stored here for files
-  uint32_t sibling;
-  uint32_t dtModify;
-  uint32_t dtCreate;
-  uint8_t isdir;
-  uint8_t scanned;
-  uint16_t store; // index int physical storage (0 ... num_storages-1)
-  char name[MAX_FILENAME_LEN];
-};
-
 class MTPStorage final {
 public:
-	MTPStorage() { fsCount = 0; }
+	struct Record {
+	  uint32_t parent;
+	  uint32_t child; // size stored here for files
+	  uint32_t sibling;
+	  uint32_t dtModify;
+	  uint32_t dtCreate;
+	  uint8_t isdir;
+	  uint8_t scanned;
+	  uint16_t store; // index int physical storage (0 ... num_storages-1)
+	  char name[MAX_FILENAME_LEN];
+	};
+	constexpr MTPStorage() {  }
 	uint32_t addFilesystem(FS &disk, const char *diskname);
 	uint32_t addFilesystem(FS &fs, const char *name, void *unused1, uint32_t unused2) {
 		return addFilesystem(fs, name);
@@ -167,17 +166,17 @@ public:
 	void loop() {
 	}
 private:
-	unsigned int fsCount;
-	const char *name[MTPD_MAX_FILESYSTEMS];
-	FS *fs[MTPD_MAX_FILESYSTEMS];
-	uint32_t store_first_child_[MTPD_MAX_FILESYSTEMS];
-	uint8_t store_scanned_[MTPD_MAX_FILESYSTEMS];
-	uint8_t store_storage_minor_index_[MTPD_MAX_FILESYSTEMS];
+	unsigned int fsCount = 0;
+	const char *name[MTPD_MAX_FILESYSTEMS] = {nullptr};
+	FS *fs[MTPD_MAX_FILESYSTEMS] = {nullptr};
+	uint32_t store_first_child_[MTPD_MAX_FILESYSTEMS] = {0};
+	uint8_t store_scanned_[MTPD_MAX_FILESYSTEMS] = {0};
+	uint8_t store_storage_minor_index_[MTPD_MAX_FILESYSTEMS] = {0};
 	uint32_t index_entries_ = 0;
 	bool index_generated = false;
 	bool all_scanned_ = false;
-	uint32_t next_;
-	bool follow_sibling_;
+	uint32_t next_ = 0;
+	bool follow_sibling_ = 0;
 	File index_;
 	File file_;
 	File child_;

--- a/src/MTP_Teensy.h
+++ b/src/MTP_Teensy.h
@@ -58,17 +58,17 @@ extern volatile uint8_t usb_configuration;
 }
 
 // MTP Responder.
-class MTPD {
+class MTP_class {
 public:
-  explicit MTPD(MTPStorage *storage) : storage_(storage) {}
+  explicit MTP_class() {}
   int begin();
+  uint32_t addFilesystem(FS &disk, const char *diskname) {return storage_.addFilesystem(disk, diskname);}
 
   static inline Stream *PrintStream(void) { return printStream_; }
   static void PrintStream(Stream *stream) { printStream_ = stream; }
-
+  MTPStorage *storage() {return &storage_ ;}
 private:
   friend class MTPStorage;
-  MTPStorage *storage_;
   static Stream *printStream_;
 
   struct MTPHeader {
@@ -186,7 +186,7 @@ private:
   uint32_t setObjectPropValue(uint32_t p1, uint32_t p2);
   uint32_t formatStore(struct MTPContainer &cmd);
   
-  static MTPD *g_pmtpd_interval;
+  static MTP_class *g_pmtpd_interval;
   static void _interval_timer_handler();
   static IntervalTimer g_intervaltimer;
   void processIntervalTimer();
@@ -213,7 +213,7 @@ public:
       uint32_t cb); // you can extend the send object buffer by this buffer
 
  inline uint32_t Store2Storage(uint32_t store) {
-    return ((store + 1) << 16) | storage_->storeMinorIndex(store);
+    return ((store + 1) << 16) | storage_.storeMinorIndex(store);
   }
   static inline uint32_t Storage2Store(uint32_t storage) {
     return (storage >> 16) - 1;
@@ -241,7 +241,10 @@ public:
   uint32_t dtFormatStart_ = 0;
   static const uint32_t MAX_FORMAT_TIME_ = 2750; // give a little time. 
   bool storage_ids_sent_ = false;
+  MTPStorage storage_;
 
 };
+
+extern MTP_class MTP;
 
 #endif


### PR DESCRIPTION
A simple pass to maybe make example sketches a little cleaner.

Renamed MTPD class to MTP_class like most of the usb classes are of names like:
usb_keyboard_class.

Defined  a standard object: MTP_class MTP

Removed MTPStorage from being a top level object and instead an object contained withing the MTP object.
Moved the Record structure to be contained within the MTPStorage class
Also made the constructor to be constexpr

Added a few wrappers  to have top level MTP.addFileSystem that calls through to the storage one.

added storage() to return pointer to it...

Note: the storage() method may be temporary as we should provide top level object methods for doing
all of the standard functionality.  We may decide to remove it or only use it for non-standard things
like debug functions for dumping the current indexl list.

created keywords.txt file
Updated library.properties file to only include the main header.  This may also be temporary
as this may be automaticaly included when a proper USB type is choosen.

Updated a few of the sketches to use these updates:
	Update Example_2_simple_t41_qflash
	Update Example_3_simple_SD.ino
    Update ssimple_t41_qflash sketch to use this updated stuff.
    Added Probably temporary - added my hardware fs class sketch