### PR TITLE
Reduce need to use MTP.storage()->

### DIFF
--- a/examples/SD_Program_SPI_QSPI_MTP-logger/SD_Program_SPI_QSPI_MTP-logger.ino
+++ b/examples/SD_Program_SPI_QSPI_MTP-logger/SD_Program_SPI_QSPI_MTP-logger.ino
@@ -158,7 +158,7 @@ void setup() {
     DBGSerial.printf("Ram Drive of size: %u initialized\n", LFSRAM_SIZE);
     uint32_t istore = MTP.addFilesystem(lfsram, "RAM");
     if (istore != 0xFFFFFFFFUL) {
-      MTP.storage()->setIndexStore(istore);
+      MTP.useFileSystemIndexToStoreIndexFile(istore);
       DBGSerial.printf("Set Storage Index drive to %u\n", istore);
     }
   }
@@ -225,12 +225,12 @@ void loop() {
     switch (command) {
     case '1': {
       // first dump list of storages:
-      uint32_t fsCount = MTP.storage()->getFSCount();
+      uint32_t fsCount = MTP.getFilesystemCount();
       DBGSerial.printf("\nDump Storage list(%u)\n", fsCount);
       for (uint32_t ii = 0; ii < fsCount; ii++) {
         DBGSerial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
-                         MTP.Store2Storage(ii), MTP.storage()->getStoreName(ii),
-                         (uint32_t)MTP.storage()->getStoreFS(ii));
+                         MTP.Store2Storage(ii), MTP.getFilesystemNameByIndex(ii),
+                         (uint32_t)MTP.getFilesystemByIndex(ii));
       }
       DBGSerial.println("\nDump Index List");
       MTP.storage()->dumpIndexList();
@@ -240,11 +240,11 @@ void loop() {
       while (ch == ' ') {
         ch = DBGSerial.read();
       }
-      if (storage_index < MTP.storage()->getFSCount()) {
+      if (storage_index < MTP.getFilesystemCount()) {
         DBGSerial.printf("Storage Index %u Name: %s Selected\n", storage_index,
-                         MTP.storage()->getStoreName(storage_index));
+                         MTP.getFilesystemNameByIndex(storage_index));
         myfs_index = storage_index;
-        myfs = MTP.storage()->getStoreFS(storage_index);
+        myfs = MTP.getFilesystemByIndex(storage_index);
         current_store = storage_index;
       } else {
         DBGSerial.printf("Storage Index %u out of range\n", storage_index);

--- a/examples/Simplified Examples/Example_1_MTP_LittleFS/Example_1_MTP_LittleFS.ino
+++ b/examples/Simplified Examples/Example_1_MTP_LittleFS/Example_1_MTP_LittleFS.ino
@@ -128,7 +128,7 @@ void setup()
   // MTP.addFilesystem(sNand, "sNand");
 
   // sets the storage for the index file
-  MTP.storage()->setIndexStore(0);
+  MTP.useFileSystemIndexToStoreIndexFile(0);
   Serial.println("\nSetup done");
 
 }

--- a/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
+++ b/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
@@ -40,11 +40,11 @@ void loop()
     switch (command) {
       case '1':
         // first dump list of storages:
-        fsCount = MTP.storage()->getFSCount();
+        fsCount = MTP.getFilesystemCount();
         Serial.printf("\nDump Storage list(%u)\n", fsCount);
         for (uint32_t ii = 0; ii < fsCount; ii++) {
           Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii, MTP.Store2Storage(ii),
-                           MTP.storage()->getStoreName(ii), (uint32_t)MTP.storage()->getStoreFS(ii));
+                           MTP.getFilesystemNameByIndex(ii), (uint32_t)MTP.getFilesystemByIndex(ii));
         }
         Serial.println("\nDump Index List");
         MTP.storage()->dumpIndexList();

--- a/examples/simple_mtp_hardware/simple_mtp_hardware.ino
+++ b/examples/simple_mtp_hardware/simple_mtp_hardware.ino
@@ -88,19 +88,19 @@ void loop() {
       break;
     case '1': {
       // first dump list of storages:
-      uint32_t fsCount = MTP.storage()->getFSCount();
+      uint32_t fsCount = MTP.getFilesystemCount();
       Serial.printf("\nDump Storage list(%u)\n", fsCount);
       for (uint32_t ii = 0; ii < fsCount; ii++) {
         Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
-                      MTP.Store2Storage(ii), MTP.storage()->getStoreName(ii),
-                      (uint32_t)MTP.storage()->getStoreFS(ii));
+                      MTP.Store2Storage(ii), MTP.getFilesystemNameByIndex(ii),
+                      (uint32_t)MTP.getFilesystemByIndex(ii));
       }
       Serial.println("\nDump Index List");
       MTP.storage()->dumpIndexList();
     } break;
     case '2':
       Serial.printf("Drive # %d Selected\n", drive_index);
-      myfs = MTP.storage()->getStoreFS(drive_index);
+      myfs = MTP.getFilesystemByIndex(drive_index);
       break;
     case 'r':
       Serial.println("Send Device Reset Event");

--- a/keywords.txt
+++ b/keywords.txt
@@ -2,7 +2,10 @@ MTP	KEYWORD1
 begin	KEYWORD2
 addFilesystem	KEYWORD2
 loop	KEYWORD2
-storage	KEYWORD2
+getFilesystemCount	KEYWORD2
+getFilesystemByIndex	KEYWORD2
+getFilesystemNameByIndex	KEYWORD2
+useFileSystemIndexToStoreIndexFile	KEYWORD2
 Store2Storage	KEYWORD2
 addSendObjectBuffer	KEYWORD2
 send_Event	KEYWORD2

--- a/src/MTP_Teensy.h
+++ b/src/MTP_Teensy.h
@@ -62,7 +62,15 @@ class MTP_class {
 public:
   explicit constexpr MTP_class() {}
   int begin();
-  uint32_t addFilesystem(FS &disk, const char *diskname) {return storage_.addFilesystem(disk, diskname);}
+  void loop(void);
+
+  // methods to add and query storage information.
+  inline uint32_t addFilesystem(FS &disk, const char *diskname) { return storage_.addFilesystem(disk, diskname); }
+  inline uint32_t getFilesystemCount(void) { return storage_.getFSCount(); }
+  inline FS* getFilesystemByIndex(uint32_t store) { return storage_.getStoreFS(store); }
+  inline const char *getFilesystemNameByIndex(uint32_t store) { return storage_.getStoreName(store); }
+  inline bool useFileSystemIndexToStoreIndexFile(uint32_t store = 0) { return storage_.setIndexStore(store); }
+  inline uint32_t getFilesystemIndexFromName(const char *fsname) { return storage_.getStoreID(fsname); }
 
   static inline Stream *PrintStream(void) { return printStream_; }
   static void PrintStream(Stream *stream) { printStream_ = stream; }
@@ -186,7 +194,6 @@ private:
 #endif
 
 public:
-  void loop(void);
   void test(void);
   operator bool() { return usb_configuration && (sessionID_ != 0); }
 


### PR DESCRIPTION
Added most all of the functions one might need from accessing the storage object,
by adding functions in main MTP

With verbose names