### PR TITLE
Updated examples for new MTP storage Wrapper & changed 1 wrapper name

### DIFF
--- a/examples/SD_Program_SPI_QSPI_MTP-logger/SD_Program_SPI_QSPI_MTP-logger.ino
+++ b/examples/SD_Program_SPI_QSPI_MTP-logger/SD_Program_SPI_QSPI_MTP-logger.ino
@@ -158,7 +158,7 @@ void setup() {
     DBGSerial.printf("Ram Drive of size: %u initialized\n", LFSRAM_SIZE);
     uint32_t istore = MTP.addFilesystem(lfsram, "RAM");
     if (istore != 0xFFFFFFFFUL) {
-      MTP.useFileSystemIndexToStoreIndexFile(istore);
+      MTP.storage()->setIndexStore(istore);
       DBGSerial.printf("Set Storage Index drive to %u\n", istore);
     }
   }
@@ -225,12 +225,12 @@ void loop() {
     switch (command) {
     case '1': {
       // first dump list of storages:
-      uint32_t fsCount = MTP.getFilesystemCount();
+      uint32_t fsCount = MTP.storage()->getFSCount();
       DBGSerial.printf("\nDump Storage list(%u)\n", fsCount);
       for (uint32_t ii = 0; ii < fsCount; ii++) {
         DBGSerial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
-                         MTP.Store2Storage(ii), MTP.getFilesystemNameByIndex(ii),
-                         (uint32_t)MTP.getFilesystemByIndex(ii));
+                         MTP.Store2Storage(ii), MTP.storage()->getStoreName(ii),
+                         (uint32_t)MTP.storage()->getStoreFS(ii));
       }
       DBGSerial.println("\nDump Index List");
       MTP.storage()->dumpIndexList();
@@ -240,11 +240,11 @@ void loop() {
       while (ch == ' ') {
         ch = DBGSerial.read();
       }
-      if (storage_index < MTP.getFilesystemCount()) {
+      if (storage_index < MTP.storage()->getFSCount()) {
         DBGSerial.printf("Storage Index %u Name: %s Selected\n", storage_index,
-                         MTP.getFilesystemNameByIndex(storage_index));
+                         MTP.storage()->getStoreName(storage_index));
         myfs_index = storage_index;
-        myfs = MTP.getFilesystemByIndex(storage_index);
+        myfs = MTP.storage()->getStoreFS(storage_index);
         current_store = storage_index;
       } else {
         DBGSerial.printf("Storage Index %u out of range\n", storage_index);

--- a/examples/Simplified Examples/Example_1_MTP_LittleFS/Example_1_MTP_LittleFS.ino
+++ b/examples/Simplified Examples/Example_1_MTP_LittleFS/Example_1_MTP_LittleFS.ino
@@ -128,7 +128,7 @@ void setup()
   // MTP.addFilesystem(sNand, "sNand");
 
   // sets the storage for the index file
-  MTP.useFileSystemIndexToStoreIndexFile(0);
+  MTP.useFileSystemIndexFileStore(0);
   Serial.println("\nSetup done");
 
 }

--- a/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
+++ b/examples/Simplified Examples/Example_2_simple_t41_qflash/Example_2_simple_t41_qflash.ino
@@ -40,11 +40,11 @@ void loop()
     switch (command) {
       case '1':
         // first dump list of storages:
-        fsCount = MTP.getFilesystemCount();
+        fsCount = MTP.storage()->getFSCount();
         Serial.printf("\nDump Storage list(%u)\n", fsCount);
         for (uint32_t ii = 0; ii < fsCount; ii++) {
           Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii, MTP.Store2Storage(ii),
-                           MTP.getFilesystemNameByIndex(ii), (uint32_t)MTP.getFilesystemByIndex(ii));
+                           MTP.getFilesystemNameByIndex(ii), (uint32_t)getFilesystemByIndex(ii));
         }
         Serial.println("\nDump Index List");
         MTP.storage()->dumpIndexList();

--- a/examples/simple_mtp_hardware/simple_mtp_hardware.ino
+++ b/examples/simple_mtp_hardware/simple_mtp_hardware.ino
@@ -88,19 +88,19 @@ void loop() {
       break;
     case '1': {
       // first dump list of storages:
-      uint32_t fsCount = MTP.getFilesystemCount();
+      uint32_t fsCount = MTP.storage()->getFSCount();
       Serial.printf("\nDump Storage list(%u)\n", fsCount);
       for (uint32_t ii = 0; ii < fsCount; ii++) {
         Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
-                      MTP.Store2Storage(ii), MTP.getFilesystemNameByIndex(ii),
-                      (uint32_t)MTP.getFilesystemByIndex(ii));
+                      MTP.Store2Storage(ii), MTP.storage()->getStoreName(ii),
+                      (uint32_t)MTP.storage()->getStoreFS(ii));
       }
       Serial.println("\nDump Index List");
       MTP.storage()->dumpIndexList();
     } break;
     case '2':
       Serial.printf("Drive # %d Selected\n", drive_index);
-      myfs = MTP.getFilesystemByIndex(drive_index);
+      myfs = MTP.storage()->getStoreFS(drive_index);
       break;
     case 'r':
       Serial.println("Send Device Reset Event");

--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@ loop	KEYWORD2
 getFilesystemCount	KEYWORD2
 getFilesystemByIndex	KEYWORD2
 getFilesystemNameByIndex	KEYWORD2
-useFileSystemIndexToStoreIndexFile	KEYWORD2
+useFileSystemIndexFileStoreKEYWORD2
 Store2Storage	KEYWORD2
 addSendObjectBuffer	KEYWORD2
 send_Event	KEYWORD2

--- a/src/MTP_Teensy.h
+++ b/src/MTP_Teensy.h
@@ -69,7 +69,7 @@ public:
   inline uint32_t getFilesystemCount(void) { return storage_.getFSCount(); }
   inline FS* getFilesystemByIndex(uint32_t store) { return storage_.getStoreFS(store); }
   inline const char *getFilesystemNameByIndex(uint32_t store) { return storage_.getStoreName(store); }
-  inline bool useFileSystemIndexToStoreIndexFile(uint32_t store = 0) { return storage_.setIndexStore(store); }
+  inline bool useFileSystemIndexFileStore(uint32_t store = 0) { return storage_.setIndexStore(store); }
   inline uint32_t getFilesystemIndexFromName(const char *fsname) { return storage_.getStoreID(fsname); }
 
   static inline Stream *PrintStream(void) { return printStream_; }


### PR DESCRIPTION
@PaulStoffregen - @KurtE - @Defragster 
I updated 2 of examples to use the new wrapper functions as well as changing the name for one of the wrappers. 
changed
useFileSystemIndexToStoreIndexFile
to
useFileSystemIndexFileStore

maybe better would be 
setFileSystemIndexFileStore
