### PR TITLE
Add a Memory File approach to Index File...

### DIFF
--- a/examples/SD_MTP_debug/SD_MTP_debug.ino
+++ b/examples/SD_MTP_debug/SD_MTP_debug.ino
@@ -1,0 +1,171 @@
+#include <SD.h>
+#include <MTP_Teensy.h>
+
+#define CS_SD BUILTIN_SDCARD  // Works on T_3.6 and T_4.1
+#define CS_SD2 10
+
+#ifdef CS_SD2
+SDClass sdSPI;
+#endif
+
+#ifdef ARDUINO_TEENSY41
+extern "C" uint8_t external_psram_size;
+#endif
+
+class RAMStream : public Stream {
+public:
+  // overrides for Stream
+  virtual int available() { return (tail_ - head_); }
+  virtual int read() { return (tail_ != head_) ? buffer_[head_++] : -1; }
+  virtual int peek() { return (tail_ != head_) ? buffer_[head_] : -1; }
+
+  // overrides for Print
+  virtual size_t write(uint8_t b) {
+    if (tail_ < buffer_size) {
+      buffer_[tail_++] = b;
+      return 1;
+    }
+    return 0;
+  }
+
+  enum { BUFFER_SIZE = 32768 };
+//  uint8_t buffer_[BUFFER_SIZE];
+  uint8_t *buffer_ = nullptr;
+  uint32_t buffer_size = BUFFER_SIZE;
+  uint32_t head_ = 0;
+  uint32_t tail_ = 0;
+};
+
+RAMStream rstream;
+
+//#define CS_SD 10  // Works on SPI with this CS pin
+void setup()
+{
+
+  // see if external memory
+#ifdef ARDUINO_TEENSY41
+  if (external_psram_size) {
+    rstream.buffer_size = 2097152;
+    rstream.buffer_ = (uint8_t*)extmem_malloc(rstream.buffer_size);
+    Serial.printf("extmem_malloc %p %u %u\n", rstream.buffer_, rstream.buffer_size, external_psram_size);
+  }
+#endif
+  if (!rstream.buffer_) {
+    rstream.buffer_ = (uint8_t*)malloc(rstream.buffer_size);
+    Serial.printf("malloc %p %u\n", rstream.buffer_, rstream.buffer_size);
+  }
+
+
+  // mandatory to begin the MTP session.
+  //MTP.PrintStream(&rstream); // Setup which stream to use...  MTP.begin();
+  MTP.begin();
+
+  Serial.begin(9600);
+  while (!Serial && millis() < 5000) {
+    // wait for serial port to connect.
+  }
+
+  if (CrashReport) Serial.print(CrashReport);
+
+  // Add SD Card
+  if (SD.begin(CS_SD)) {
+    Serial.println("Added SD card using built in SDIO, or given SPI CS");
+  } else {
+    Serial.println("No SD Card");
+  }
+  MTP.addFilesystem(SD, "SD1");
+#ifdef CS_SD2
+  if (sdSPI.begin(CS_SD2)) {
+    Serial.println("Added SD2 card using built in SDIO, or given SPI CS");
+  } else {
+    Serial.println("SD2 card not present");
+  }
+  MTP.addFilesystem(sdSPI, "SD2");
+#endif
+
+  //MTP.useFileSystemIndexFileStore(MTPStorage::INDEX_STORE_MEM_FILE);
+  Serial.println("\nSetup done");
+}
+
+
+uint8_t print_buffer[256];
+void print_capture_data() {
+
+  #ifdef ARDUINO_TEENSY41
+  Serial.printf("Capture size: %d out of %d PS:%u\n", rstream.available(), rstream.buffer_size, external_psram_size);
+  #else
+  Serial.printf("Capture size: %d out of %d\n", rstream.available(), rstream.buffer_size);
+  #endif
+  
+  int avail;
+  while ((avail = rstream.available())) {
+    if (avail > (int)sizeof(print_buffer)) avail = sizeof(print_buffer);
+
+    int avail_for_write = Serial.availableForWrite();
+    if (avail_for_write < avail) avail = avail_for_write;
+    rstream.readBytes(print_buffer, avail);
+    Serial.write(print_buffer, avail);
+
+  } 
+
+
+  int ch;
+  while ((ch = rstream.read()) != -1)
+    Serial.write(ch);
+}
+
+void loop() {
+  MTP.loop();  //This is mandatory to be placed in the loop code.
+
+  if (Serial.available()) {
+    uint8_t command = Serial.read();
+    switch (command) {
+    case 'c':
+      // start capture debug info
+      rstream.head_ = 0;
+      rstream.tail_ = 0;
+      MTP.PrintStream(&rstream); // Setup which stream to use...
+      Serial.println("Capturing MTP debug output");
+      break;
+    case 's':
+      Serial.println("Stop Captured data");
+      rstream.head_ = 0;
+      rstream.tail_ = 0;
+      break;
+    case 'p':
+      MTP.PrintStream(&Serial); // Setup which stream to use...
+      Serial.println("Print Captured data");
+      print_capture_data();
+      rstream.head_ = 0;
+      rstream.tail_ = 0;
+      break;
+    case 'r':
+      Serial.println("Reset");
+      MTP.send_DeviceResetEvent();
+      break;
+    case 'd':
+      // first dump list of storages:
+      {
+        uint32_t fsCount = MTP.getFilesystemCount();
+        Serial.printf("\nDump Storage list(%u)\n", fsCount);
+        for (uint32_t ii = 0; ii < fsCount; ii++) {
+          Serial.printf("store:%u storage:%x name:%s fs:%x\n", ii,
+                        MTP.Store2Storage(ii), MTP.getFilesystemNameByIndex(ii),
+                        (uint32_t)MTP.getFilesystemNameByIndex(ii));
+        }
+        Serial.println("\nDump Index List");
+        MTP.storage()->dumpIndexList();
+      }
+      break;
+    default:  
+      Serial.println("Menu");
+      Serial.println("\t c - start capture debug data");
+      Serial.println("\t p - Stop capture and print");
+      Serial.println("\t s - stop capture and discard");
+      Serial.println("\t d - dump storage info");
+      Serial.println("\t r - Send MTP Reset");
+    }
+    while (Serial.read() != -1);
+  }
+
+}

--- a/src/MTP_Storage.h
+++ b/src/MTP_Storage.h
@@ -88,7 +88,7 @@ public:
 	// upper 10 (or 26 if I go back to 32 bits) will be the 2K record number to
 	// read and write. 
 	enum {MAX_RECORDS_PER_BLOCK=64, BLOCK_SIZE=2048, BLOCK_SIZE_DATA=BLOCK_SIZE - (2*MAX_RECORDS_PER_BLOCK + 3),
-		BLOCK_SIZE_NAME_FUDGE=64};
+		BLOCK_SIZE_NAME_FUDGE=64, INDEX_STORE_MEM_FILE=(uint32_t)-2};
 	struct RecordBlock {
 		uint16_t recordOffsets[MAX_RECORDS_PER_BLOCK];
 		uint16_t dataIndexNextFree; 

--- a/src/MTP_Teensy.h
+++ b/src/MTP_Teensy.h
@@ -29,7 +29,7 @@
 #define MTP_TEENSY_H
 
 #if !defined(USB_MTPDISK) && !defined(USB_MTPDISK_SERIAL)
-#error "You need to select USB Type: 'MTP Disk (Experimental)'"
+#error "You need to select USB Type: 'MTP Disk (Experimental)' or 'Serial + MTP Disk (Experimental)'"
 #endif
 
 #if TEENSYDUINO < 157


### PR DESCRIPTION
We have run into cases of where the MTP code won't work if for example your
MTP storage list, starts with SD slot and there is no SD in the slot... Or SD is marked
read only.

Right now the code has a way to use the internal memory FS if the user specifies to use the storage index of -2...
But in addition to this, the code will automatically choose this if it fails to open up the storage index file
on the selected (Default first) storage location that was added to MTP

Fix maybe an index issue, by clearing the count of how many records have been stored, when the index file is reopened.
plus change to setting if we should send the reset instead of looking at command which

Fixed a few places which were not building on T3.2